### PR TITLE
Parametrize max depth

### DIFF
--- a/force-app/main/default/classes/DescendantSearch.cls
+++ b/force-app/main/default/classes/DescendantSearch.cls
@@ -9,7 +9,6 @@ public class DescendantSearch {
   String query;
   Integer maxDepthForIteration;
 
-
   /**
    * Constructor
    * @param sobType The SObject Type to search on

--- a/force-app/main/default/classes/DescendantSearch.cls
+++ b/force-app/main/default/classes/DescendantSearch.cls
@@ -16,7 +16,7 @@ public class DescendantSearch {
    * @param parentField The Master-Detail or Lookup relationship to traverse
    */
   public DescendantSearch(SObjectType sobType, SObjectField relationship) {
-    this(sobType, relationship, 5);
+    this(sobType, relationship, HierarchicalSearchUtil.DEFAULT_MAX_DEPTH);
   }
 
   /**

--- a/force-app/main/default/classes/DescendantSearch.cls
+++ b/force-app/main/default/classes/DescendantSearch.cls
@@ -7,6 +7,8 @@ public class DescendantSearch {
   SObjectType sobType;
   SObjectField relationship;
   String query;
+  Integer maxDepthForIteration;
+
 
   /**
    * Constructor
@@ -14,8 +16,19 @@ public class DescendantSearch {
    * @param parentField The Master-Detail or Lookup relationship to traverse
    */
   public DescendantSearch(SObjectType sobType, SObjectField relationship) {
+    this(sobType, relationship, 5);
+  }
+
+  /**
+   * Constructor
+   * @param sobType The SObject Type to search on
+   * @param parentField The Master-Detail or Lookup relationship to traverse
+   * @param how many relationship field to query at the same time. This may help when ORA-00972 appears
+   */
+  public DescendantSearch(SObjectType sobType, SObjectField relationship, Integer maxDepthForIteration) {
     this.relationship = relationship;
     this.sobType = sobType;
+    this.maxDepthForIteration = maxDepthForIteration;
     query = generateQuery();
   }
 
@@ -41,7 +54,7 @@ public class DescendantSearch {
       TrunkReference tr = getTrunkReference(child, 1, leafTrunkMap);
       Id trunkId = tr.trunkId;
 
-      if (tr.depth == 6) {
+      if (isDeepestDepth(tr.depth)) {
         // matched at deepest depth, there MAY still be children at deeper depths
         potentialLeafMap.put(child.Id, trunkId);
       }
@@ -104,7 +117,7 @@ public class DescendantSearch {
         ParentId NULLS LAST
    */
   private String generateQuery() {
-    String[] selectList = HierarchicalSearchUtil.generateMaxTraverseFields(relationship);
+    String[] selectList = HierarchicalSearchUtil.generateMaxTraverseFields(this.relationship, this.maxDepthForIteration);
     Integer fieldSize = selectList.size();
 
     String[] whereList = new List<String>{};
@@ -126,6 +139,10 @@ public class DescendantSearch {
         String.join(orderList, ',\n')
       }
     );
+  }
+
+  private Boolean isDeepestDepth(Integer depth) {
+    return depth > this.maxDepthForIteration;
   }
 
   //inner classed use to hold Trunk information

--- a/force-app/main/default/classes/HierarchicalSearchTests.cls
+++ b/force-app/main/default/classes/HierarchicalSearchTests.cls
@@ -55,6 +55,25 @@ public class HierarchicalSearchTests {
   }
 
   @isTest
+  private static void rootSearchWideDepth4() {
+    List<Account> accounts = createAccountChain(3);
+
+    List<Account> widen = new List<Account>{
+      new Account(Name = '2-2', ParentId = accounts[1].Id),
+      new Account(Name = '3-2', ParentId = accounts[2].Id),
+      new Account(Name = '3-3', ParentId = accounts[2].Id),
+      new Account(Name = '3-4', ParentId = accounts[2].Id)
+    };
+    insert widen;
+
+    RootSearch r = new RootSearch(Account.getSObjectType(), Account.ParentId, 4);
+    Map<Id, Id> roots = r.search(new Map<Id, Account>(widen).keySet());
+    for (Account acc : widen) {
+      System.assertEquals(accounts[0].Id, roots.get(acc.Id));
+    }
+  }
+
+  @isTest
   private static void rootSearchDeep() {
     List<Account> accounts = createAccountChain(10);
 
@@ -84,6 +103,27 @@ public class HierarchicalSearchTests {
     List<Account> accounts = createAccountChain(13);
 
     DescendantSearch r = new DescendantSearch(Account.sObjectType, Account.ParentId);
+    Map<Id, Id[]> children = r.search(new Set<Id>{ accounts[0].id });
+    System.assert(children.containsKey(accounts[0].Id));
+    System.assertEquals(12, children.get(accounts[0].Id).size());
+
+    children = r.search(new Set<Id>{ accounts[2].id });
+    System.assert(children.containsKey(accounts[2].Id));
+    System.assertEquals(10, children.get(accounts[2].Id).size());
+
+    children = r.search(new Set<Id>{ accounts[9].id });
+    System.assert(children.containsKey(accounts[9].Id));
+    System.assertEquals(3, children.get(accounts[9].Id).size());
+
+    children = r.search(new Set<Id>{ accounts[12].id });
+    System.assert(!children.containsKey(accounts[12].Id));
+  }
+
+  @isTest
+  private static void descendantSearchDeepTestDepth3() {
+    List<Account> accounts = createAccountChain(13);
+
+    DescendantSearch r = new DescendantSearch(Account.sObjectType, Account.ParentId, 3);
     Map<Id, Id[]> children = r.search(new Set<Id>{ accounts[0].id });
     System.assert(children.containsKey(accounts[0].Id));
     System.assertEquals(12, children.get(accounts[0].Id).size());

--- a/force-app/main/default/classes/HierarchicalSearchUtil.cls
+++ b/force-app/main/default/classes/HierarchicalSearchUtil.cls
@@ -3,9 +3,7 @@
  *  Helpers for RootSearch and Descendant search
  */
 public class HierarchicalSearchUtil {
-  public static String[] generateMaxTraverseFields(SObjectField relationship) {
-    return generateMaxTraverseFields(relationship, 5);
-  }
+  public static final Integer DEFAULT_MAX_DEPTH = 5;
 
   public static String[] generateMaxTraverseFields(SObjectField relationship, Integer depth) {
     Schema.DescribeFieldResult describe = relationship.getDescribe();

--- a/force-app/main/default/classes/HierarchicalSearchUtil.cls
+++ b/force-app/main/default/classes/HierarchicalSearchUtil.cls
@@ -4,12 +4,16 @@
  */
 public class HierarchicalSearchUtil {
   public static String[] generateMaxTraverseFields(SObjectField relationship) {
+    return generateMaxTraverseFields(relationship, 5);
+  }
+
+  public static String[] generateMaxTraverseFields(SObjectField relationship, Integer depth) {
     Schema.DescribeFieldResult describe = relationship.getDescribe();
     String rName = describe.getRelationshipName();
     String cName = describe.getName();
 
     String[] relFields = new List<String>{};
-    for (Integer i = 0; i <= 5; i++) {
+    for (Integer i = 0; i <= depth; i++) {
       String[] nParts = new List<String>{};
       for (Integer j = 0; j < i; j++) {
         nParts.add(rName);

--- a/force-app/main/default/classes/RootSearch.cls
+++ b/force-app/main/default/classes/RootSearch.cls
@@ -7,6 +7,7 @@ public class RootSearch {
   SObjectType sobType;
   SObjectField parentField;
   String query;
+  Integer maxDepthForIteration;
 
   /**
    * Constructor
@@ -14,8 +15,18 @@ public class RootSearch {
    * @param parentField The Master-Detail or Lookup relationship to traverse
    */
   public RootSearch(SObjectType sobType, SObjectField parentField) {
+    this(sobType, parentField, 5);
+  }
+
+  /**
+   * Constructor
+   * @param sobType The SObject Type to search on
+   * @param parentField The Master-Detail or Lookup relationship to traverse
+   */
+  public RootSearch(SObjectType sobType, SObjectField parentField, Integer maxDepthForIteration) {
     this.sobType = sobType;
     this.parentField = parentField;
+    this.maxDepthForIteration = maxDepthForIteration;
     this.query = generateQuery();
   }
 
@@ -54,7 +65,7 @@ public class RootSearch {
       return new RootSearchResult(foundRoots.get(sob.Id), true);
     }
 
-    Boolean maxDepth = depth == 5;
+    Boolean maxDepth = isMaxDepth(depth);
     SObject parent = sob.getSObject(this.parentField);
     if (parent == null || maxDepth) {
       return new RootSearchResult(sob.Id, !maxDepth);
@@ -76,11 +87,15 @@ public class RootSearch {
       WHERE Id IN :ids
    */
   private String generateQuery() {
-    String[] fields = HierarchicalSearchUtil.generateMaxTraverseFields(this.parentField);
+    String[] fields = HierarchicalSearchUtil.generateMaxTraverseFields(this.parentField, this.maxDepthForIteration);
     return String.format(
       'SELECT {0} \nFROM {1} \nWHERE Id IN :ids',
       new List<String>{ String.join(fields, ',\n'), this.sobType.getDescribe().getName() }
     );
+  }
+
+  private Boolean isMaxDepth(Integer depth) {
+    return depth == this.maxDepthForIteration;
   }
 
   private class RootSearchResult {

--- a/force-app/main/default/classes/RootSearch.cls
+++ b/force-app/main/default/classes/RootSearch.cls
@@ -15,7 +15,7 @@ public class RootSearch {
    * @param parentField The Master-Detail or Lookup relationship to traverse
    */
   public RootSearch(SObjectType sobType, SObjectField parentField) {
-    this(sobType, parentField, 5);
+    this(sobType, parentField, HierarchicalSearchUtil.DEFAULT_MAX_DEPTH);
   }
 
   /**

--- a/force-app/main/default/classes/RootSearch.cls
+++ b/force-app/main/default/classes/RootSearch.cls
@@ -22,6 +22,7 @@ public class RootSearch {
    * Constructor
    * @param sobType The SObject Type to search on
    * @param parentField The Master-Detail or Lookup relationship to traverse
+   * @param how many relationship field to query at the same time. This may help when ORA-00972 appears
    */
   public RootSearch(SObjectType sobType, SObjectField parentField, Integer maxDepthForIteration) {
     this.sobType = sobType;

--- a/force-app/main/default/classes/RootSearch.cls
+++ b/force-app/main/default/classes/RootSearch.cls
@@ -67,8 +67,9 @@ public class RootSearch {
 
     Boolean maxDepth = isMaxDepth(depth);
     SObject parent = sob.getSObject(this.parentField);
-    if (parent == null || maxDepth) {
-      return new RootSearchResult(sob.Id, !maxDepth);
+    Boolean isParent = parent == null;
+    if (isParent || maxDepth) {
+      return new RootSearchResult(sob.Id, isParent);
     } else {
       return findRoot(parent, ++depth, foundRoots);
     }


### PR DESCRIPTION
Sometimes you need to parametrize the max depth of the query. [Here's a description](https://salesforce.stackexchange.com/questions/319845/sfdcsqlexception-ora-00972-identifier-is-too-long) of the issue I had and how I managed to solve it.

This PR adds the ability to control the depth of queries, how many relations will be extracted by a single query.